### PR TITLE
Add missing method for Document

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -154,6 +154,7 @@ impl Database {
         }
     }
 
+    /** Deletes a document from the database. Deletions are replicated. */
     pub fn delete_document_with_concurency_control(
         &mut self,
         doc: &Document,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
         props.at("i").put_i64(1234);
         props.at("s").put_string("Hello World!");
 
-        db.save_document(&mut doc, ConcurrencyControl::FailOnConflict).expect("save");
+        db.save_document_with_concurency_control(&mut doc, ConcurrencyControl::FailOnConflict).expect("save");
     }
     // Reload the document and verify its properties:
     {

--- a/tests/document_tests.rs
+++ b/tests/document_tests.rs
@@ -185,7 +185,8 @@ fn database_delete_document() {
         let mut document = Document::new_with_id("foo");
         db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict)
             .expect("save_document");
-        db.delete_document(&document).expect("delete_document");
+        db.delete_document_with_concurency_control(&document, ConcurrencyControl::FailOnConflict)
+            .expect("delete_document");
         let document = db.get_document("foo");
         // FIXME delete doesn't seem to work just like that (maybe need for replication)
         assert!(document.is_err());
@@ -264,7 +265,7 @@ fn database_add_document_change_listener() {
 
         utils::set_static(&DOCUMENT_DETECTED, false);
         let mut document = Document::new_with_id("bar");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict)
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict)
             .expect("save_document");
         assert!(utils::check_static_with_wait(
             &DOCUMENT_DETECTED,

--- a/tests/document_tests.rs
+++ b/tests/document_tests.rs
@@ -36,10 +36,10 @@ fn document_revision_id() {
     utils::with_db(|db| {
         let mut document = Document::new();
         assert_eq!(document.revision_id(), None);
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         assert!(document.revision_id().is_some());
         let first_revision_id = String::from(document.revision_id().unwrap());
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         assert!(document.revision_id().is_some());
         let second_revision_id = String::from(document.revision_id().unwrap());
         assert_ne!(second_revision_id, first_revision_id);
@@ -53,8 +53,8 @@ fn document_sequence() {
         let mut document_2 = Document::new();
         assert_eq!(document_1.sequence(), 0);
         assert_eq!(document_2.sequence(), 0);
-        db.save_document(&mut document_1, ConcurrencyControl::FailOnConflict).expect("save_document");
-        db.save_document(&mut document_2, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document_1, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document_2, ConcurrencyControl::FailOnConflict).expect("save_document");
         assert_eq!(document_1.sequence(), 1);
         assert_eq!(document_2.sequence(), 2);
     });
@@ -94,7 +94,7 @@ fn document_properties_as_json() {
 fn database_get_document() {
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         let document = db.get_document(document.id());
         assert!(document.is_ok());
         assert_eq!(document.unwrap().id(), "foo");
@@ -107,17 +107,17 @@ fn database_get_document() {
 fn database_save_document() {
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         let mut document = db.get_document("foo").expect("get_document");
         {
             let mut document = db.get_document("foo").expect("get_document");
             document.mutable_properties().at("foo").put_i64(1);
-            db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+            db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         }
         document.mutable_properties().at("foo").put_i64(2);
-        let conflict_error = db.save_document(&mut document, ConcurrencyControl::FailOnConflict);
+        let conflict_error = db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict);
         assert!(conflict_error.is_err());
-        db.save_document(&mut document, ConcurrencyControl::LastWriteWins).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::LastWriteWins).expect("save_document");
         let document = db.get_document("foo").expect("get_document");
         assert_eq!(document.properties().get("foo").as_i64_or_0(), 2);
     });
@@ -127,11 +127,11 @@ fn database_save_document() {
 fn database_save_document_resolving() {
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         {
             let mut document = db.get_document("foo").unwrap();
             document.mutable_properties().at("foo").put_i64(1);
-            db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+            db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         }
         document.mutable_properties().at("foo").put_i64(2);
         document = db.save_document_resolving(&mut document, |document_a, document_b| {
@@ -150,8 +150,8 @@ fn database_save_document_resolving() {
 fn database_delete_document() {
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
-        db.delete_document(&document, ConcurrencyControl::FailOnConflict).expect("delete_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.delete_document(&document).expect("delete_document");
         let document = db.get_document("foo");
         // FIXME delete doesn't seem to work just like that (maybe need for replication)
         assert!(document.is_err());
@@ -163,9 +163,9 @@ fn database_purge_document() {
     utils::with_db(|db| {
         let mut document = Document::new();
         {
-            db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+            db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
             let mut document = Document::new_with_id("foo");
-            db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+            db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         }
         db.purge_document(&document).expect("purge_document");
         db.purge_document_by_id("foo").expect("purge_document_by_id");
@@ -180,7 +180,7 @@ fn database_purge_document() {
 fn database_document_expiration() {
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         let expiration = db.document_expiration("foo").expect("document_expiration");
         assert!(expiration.is_none());
         db.set_document_expiration("foo", Some(Timestamp(1000000000))).expect("set_document_expiration");
@@ -200,14 +200,14 @@ fn database_add_document_change_listener() {
 
     utils::with_db(|db| {
         let mut document = Document::new_with_id("foo");
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         let listener_token = db.add_document_change_listener(&document, |_, document_id| {
             if document_id == "foo" {
                 utils::set_static(&DOCUMENT_DETECTED, true);
             }
         });
         document.mutable_properties().at("foo").put_i64(1);
-        db.save_document(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
+        db.save_document_with_concurency_control(&mut document, ConcurrencyControl::FailOnConflict).expect("save_document");
         assert!(utils::check_static_with_wait(&DOCUMENT_DETECTED, true, None));
         drop(listener_token);
     });

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -101,7 +101,7 @@ pub fn add_doc(db: &mut Database, id: &str, i: i64, s: &str) {
     let mut props = doc.mutable_properties();
     props.at("i").put_i64(i);
     props.at("s").put_string(s);
-    db.save_document(&mut doc, ConcurrencyControl::FailOnConflict).expect("save");
+    db.save_document_with_concurency_control(&mut doc, ConcurrencyControl::FailOnConflict).expect("save");
 }
 
 // Static


### PR DESCRIPTION
I'm not sure we really need to implement those.

Even in the Rust implementation I was itching to call the Rust method with concurrency (and a default parameter) rather than the mapped one.

Exposing those, while the ones with concurrency are fairly easy to call with a default value with concurency management, seems a small gain for loosing the insurance that the user is aware of the risk of data loss.

Are we sure we need/want to expose the whole C library from the Rust mapping (knowing that we're not losing functionnality not doing it) ?