### PR TITLE
Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
     - name: List libs
       run: ls -l /usr/lib
     - name: Install latest nightly
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@v1
       with:
           toolchain: nightly
           components: rustfmt, clippy


### PR DESCRIPTION
Depends on https://github.com/doctolib/kube/pull/31231